### PR TITLE
shortcutkey_viewonly

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3426,6 +3426,12 @@ static gboolean remmina_connection_window_hostkey_func(RemminaProtocolWidget* gp
 		remmina_connection_holder_toolbar_minimize(GTK_WIDGET(gp),
 				cnnhld);
 	}
+	else if (keyval == remmina_pref.shortcutkey_viewonly)
+	{
+		remmina_file_set_int(cnnobj->remmina_file, "viewonly",
+				( remmina_file_get_int(cnnobj->remmina_file, "viewonly", 0 )
+				 == 0  ) ? 1 : 0 );     
+	}
 	else if (keyval == remmina_pref.shortcutkey_screenshot)
 	{
 		remmina_connection_holder_toolbar_screenshot(GTK_WIDGET(gp),

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -484,6 +484,11 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.shortcutkey_scale = GDK_KEY_s;
 
+        if (g_key_file_has_key(gkeyfile, "remmina_pref", "shortcutkey_viewonly", NULL))
+            remmina_pref.shortcutkey_viewonly = g_key_file_get_integer(gkeyfile, "remmina_pref", "shortcutkey_viewonly", NULL);
+        else
+            remmina_pref.shortcutkey_viewonly = GDK_KEY_m;
+
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "shortcutkey_grab", NULL))
 		remmina_pref.shortcutkey_grab = g_key_file_get_integer(gkeyfile, "remmina_pref", "shortcutkey_grab", NULL);
 	else
@@ -757,6 +762,7 @@ void remmina_pref_save(void)
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_prevtab", remmina_pref.shortcutkey_prevtab);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_scale", remmina_pref.shortcutkey_scale);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_grab", remmina_pref.shortcutkey_grab);
+	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_viewonly", remmina_pref.shortcutkey_viewonly);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_screenshot", remmina_pref.shortcutkey_screenshot);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_minimize", remmina_pref.shortcutkey_minimize);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "shortcutkey_disconnect", remmina_pref.shortcutkey_disconnect);

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -129,6 +129,7 @@ typedef struct _RemminaPref
 	guint shortcutkey_nexttab;
 	guint shortcutkey_scale;
 	guint shortcutkey_grab;
+	guint shortcutkey_viewonly;
 	guint shortcutkey_screenshot;
 	guint shortcutkey_minimize;
 	guint shortcutkey_disconnect;


### PR DESCRIPTION
shortcutkey_viewonly - hardcoded Host+M - working
Patched 3 files to cause Host+M to toggle viewonly mode.
It has been very frustrating to have to move (local and remote) remote mouse pointer for the so frequent action "turn off viewonly, type / click as needed, turn on viewonly". Now it is extremely quicker to press Host+M, type / click as needed, Host+M. Patch is immediately functional, but to achieve release-grade quality, someone needs to add a button to customize the shortcut in the Preferences dialog, Keyboard tab. (I tried but failed).